### PR TITLE
Exported resources tags

### DIFF
--- a/lib/rspec-puppet/support.rb
+++ b/lib/rspec-puppet/support.rb
@@ -14,37 +14,44 @@ module RSpec::Puppet
 
       exp_res = [exp_res] if exp_res.is_a? Hash
 
-      if exp_res and ! exp_res.empty?
+      Dir.mktmpdir('puppet-sqlite') do |tmpdir|
         if can_use_scratch_database?
-          setup_scratch_database
-          scope = Puppet::Parser::Scope.new
-          catalog = Puppet::Resource::Catalog.new("mock_node")
-          exp_res.each do |types|
-            types.each do |type, resource|
-              resource.each do |title, params|
-                parser_resource = Puppet::Parser::Resource.new( type, title, {
-                  :virtual  => true,
-                  :exported => true,
-                  :scope    => scope,
-                })
-                params.each { |attribute, value| parser_resource[attribute] = value } if params
-                res = parser_resource.to_resource
-                catalog.add_resource res
+          setup_scratch_database(tmpdir)
+          if exp_res and ! exp_res.empty?
+            scope = Puppet::Parser::Scope.new
+            catalog = Puppet::Resource::Catalog.new("mock_node")
+            exp_res.each do |types|
+              types.each do |type, resource|
+                resource.each do |title, params|
+                  parser_resource = Puppet::Parser::Resource.new( type, title, {
+                    :virtual  => true,
+                    :exported => true,
+                    :scope    => scope,
+                  })
+                  params.each { |attribute, value| parser_resource[attribute] = value } if params
+                  res = parser_resource.to_resource
+                  catalog.add_resource res
+                end
               end
             end
+            request = Puppet::Indirector::Request.new(:active_record, :save, catalog)
+            Puppet::Resource::Catalog::ActiveRecord.new.save(request)
           end
-          request = Puppet::Indirector::Request.new(:active_record, :save, catalog)
-          Puppet::Resource::Catalog::ActiveRecord.new.save(request)
         else
           raise Puppet::Error, "Cannot use scratch database for exported resources."
         end
-      end
 
-      # trying to be compatible with 2.7 as well as 2.6
-      if Puppet::Resource::Catalog.respond_to? :find
-        Puppet::Resource::Catalog.find(node_obj.name, :use_node => node_obj)
-      else
-        Puppet::Resource::Catalog.indirection.find(node_obj.name, :use_node => node_obj)
+        # trying to be compatible with 2.7 as well as 2.6
+        if Puppet::Resource::Catalog.respond_to? :find
+          catalog = Puppet::Resource::Catalog.find(node_obj.name, :use_node => node_obj)
+        else
+          catalog = Puppet::Resource::Catalog.indirection.find(node_obj.name, :use_node => node_obj)
+        end
+        Puppet::Rails::PuppetTag.accumulators.each do |name,accumulator|
+          accumulator.reset
+        end
+        Puppet::Rails.teardown if defined?(ActiveRecord::Base)
+        catalog
       end
     end
 

--- a/lib/rspec-puppet/support/database.rb
+++ b/lib/rspec-puppet/support/database.rb
@@ -20,10 +20,9 @@ end
 # This is expected to be called in your `before :each` block, and will get you
 # ready to roll with a serious database and all.  Cleanup is handled
 # automatically for you.  Nothing to do there.
-def setup_scratch_database
+def setup_scratch_database(dir)
   require 'puppet/indirector/catalog/active_record'
   Puppet[:storeconfigs] = true
-  Puppet[:environment]  = "production"
   # trying to be compatible with 2.7 as well as 2.6
   begin
     Puppet[:storeconfigs_backend] = "active_record"
@@ -31,11 +30,8 @@ def setup_scratch_database
     # 2.6 has no storeconfigs_backend configuration parameter; it is
     # hard-coded to 'active_record'
   end
-  Puppet::Rails.stubs(:database_arguments).returns(
-    :adapter => 'sqlite3',
-    :log_level => Puppet[:rails_loglevel],
-    :database => ':memory:'
-  )
+  Puppet[:dbadapter]    = 'sqlite3'
+  Puppet[:dblocation]   = (dir + "/storeconfigs.sqlite").to_s
   Puppet[:railslog]     = '/dev/null'
   Puppet::Rails.init
 end

--- a/spec/classes/exported_realise_tags_spec.rb
+++ b/spec/classes/exported_realise_tags_spec.rb
@@ -1,0 +1,57 @@
+require 'spec_helper'
+
+describe 'exported::realise_tags' do
+  context 'with no exported resources' do
+    it { should_not contain_file('foo') }
+    it { should_not contain_file('bar') }
+    it { should_not contain_package('baz') }
+  end
+
+  context 'with exported resources' do
+    let(:exported_resources) do
+      [
+        'file' => {
+          'foo' => {
+            :owner => 'root',
+            :group => 'root',
+          },
+          'bar' => {
+            :owner => 'daemon',
+            :group => 'daemon',
+          }
+        },
+        'package' => {
+          'baz' => {
+            :ensure => 'present',
+          }
+        }
+      ]
+    end
+
+    it { should contain_file('foo').with_owner('root').with_group('root') }
+    it { should contain_file('bar').with_owner('daemon').with_group('daemon') }
+    it { should_not contain_package('baz') }
+  end
+
+  context 'with different exported resources' do
+    let(:exported_resources) do
+      [
+        'file' => {
+          'foo' => {
+            :owner => 'root',
+            :group => 'root',
+          }
+        },
+        'package' => {
+          'baz' => {
+            :ensure => 'present',
+          }
+        }
+      ]
+    end
+
+    it { should contain_file('foo').with_owner('root').with_group('root') }
+    it { should_not contain_file('bar') }
+    it { should_not contain_package('baz') }
+  end
+end

--- a/spec/fixtures/modules/exported/manifests/realise_tags.pp
+++ b/spec/fixtures/modules/exported/manifests/realise_tags.pp
@@ -1,0 +1,4 @@
+class exported::realise_tags {
+  File <<| tag == 'file' |>>
+  File <<| tag != 'package' |>>
+}


### PR DESCRIPTION
This pull requests adds robustness to the exported resource spec testing abilities including clearing Puppet's tag accumulator which interfered with individual spec tests.
